### PR TITLE
Remove rustfmt from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
   allow_failures:
     - rust: nightly
 
-install:
-  - cargo install rustfmt
-
 script:
   - cargo build --release --verbose
   - cargo test --verbose


### PR DESCRIPTION
Thought it had some sort of check mode, but doesn't look like it.
