### PR TITLE
Add auto publishing of tags from travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,22 @@ matrix:
   allow_failures:
     - rust: nightly
 
+env:
+  global:
+    - secure: pTlR6FCGhfVffa/q85naOZF/3R4u5xiiD9I/09SbQrkl8LgWfURrkNaiVDXtZMJJVt1MwiwGocGaWc9dScVryA9dzJBP0o/1qk0UrkLBFq4QcVgDkGcgA6xOTC/l910qRKQqTzyHiMYXMWxDCM/KxxYkMgBGcgRW0uZHIaIqgWO0lnSGFA1HBfvpWptwpRLGufwTq6RYBlXxslLjzuA1gaFA1nJR4iAhvHLzOfE5cfw5mnUkMqYzcwR4/y9/kMpgZJgVTDuYP1OC3V8STLKstrANzAwaKcwmOW3Ob4cwiEzp7DRD2PpuGdbMj3gR5WU0WIxLtFcFDPouRvzTQChOVbEoUo/DirhAgpTSDcJdKSuKrqeh1N0YLuOXd+2vspNNC1PGoe9BtJgp3I3Y/6gRMrRQF8ipAGtaDPasRRCiNAONpiLOSk8JzUAZIF3D8neZPxjPjBSuzx7caEFBLQ3xeR71A30e1zCeCSwO3mDhRE62iB8GHxuarbhnqqvFaL1iUnrwOVorapPcv1uwdntBJGTCQRuC/IBsqVmIzoTk25e/8qlHVG4JN0YBdMagqSGhX7b9bEHwKgU3zgNLx1dnTrg8aI7ouEXNZE1c77o+kO1ZQ5yyCjyAsZEgcTcwbIBtUnfKTgHmLs/7nq6nHMFQEGbruRGonCcFqRnSKSOI+J8=
+
 script:
   - cargo build --release --verbose
   - cargo test --verbose
+
+before_deploy:
+  - cargo package --verbose
+
+deploy:
+  provider: script
+  script: deploy.sh $TRAVIS_TAG $CRATES_IO_TOKEN
+  skip_cleanup: true
+  on:
+    tags: true
+    all_branches: true
+    condition: "$TRAVIS_RUST_VERSION = stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
 env:
   global:
     - secure: pTlR6FCGhfVffa/q85naOZF/3R4u5xiiD9I/09SbQrkl8LgWfURrkNaiVDXtZMJJVt1MwiwGocGaWc9dScVryA9dzJBP0o/1qk0UrkLBFq4QcVgDkGcgA6xOTC/l910qRKQqTzyHiMYXMWxDCM/KxxYkMgBGcgRW0uZHIaIqgWO0lnSGFA1HBfvpWptwpRLGufwTq6RYBlXxslLjzuA1gaFA1nJR4iAhvHLzOfE5cfw5mnUkMqYzcwR4/y9/kMpgZJgVTDuYP1OC3V8STLKstrANzAwaKcwmOW3Ob4cwiEzp7DRD2PpuGdbMj3gR5WU0WIxLtFcFDPouRvzTQChOVbEoUo/DirhAgpTSDcJdKSuKrqeh1N0YLuOXd+2vspNNC1PGoe9BtJgp3I3Y/6gRMrRQF8ipAGtaDPasRRCiNAONpiLOSk8JzUAZIF3D8neZPxjPjBSuzx7caEFBLQ3xeR71A30e1zCeCSwO3mDhRE62iB8GHxuarbhnqqvFaL1iUnrwOVorapPcv1uwdntBJGTCQRuC/IBsqVmIzoTk25e/8qlHVG4JN0YBdMagqSGhX7b9bEHwKgU3zgNLx1dnTrg8aI7ouEXNZE1c77o+kO1ZQ5yyCjyAsZEgcTcwbIBtUnfKTgHmLs/7nq6nHMFQEGbruRGonCcFqRnSKSOI+J8=
+    - secure: rMU590nAggJr3wB0tBldZdXB46dBK1UfFwMByuyYPJlYx7skao8MVJBS2sbTMiRUUiVF2LsoM2YYuoTRG5FiieXjeH/I8nvI5mpKlkPJounmontSh2zhxfK/NrQihZqZQsLrn7cDra4Ldtz9E7L2ydfj7xskAaeEO1GynCK7Q+UCMSl/HRXEVf4bv2VONzN1k61H9h7d6rk1JF4J5iZkvhvt+j3zWusiO0Y5s8/cj4ZWaXSPyoZUjdaHjwe3P89eXnoGVN8b3cMsXSxZJXxeiPTDp1V81lqsMMHHJdc75LDQujWm9l982ygpljpeaLs7xq8Y5HGWU0vBXlyQA5Xgt02s4Yz+YQ5ABldFsZXD/FQu3R0DfJumNYYoW8GWgJpE9AMYj+ZKsSUZgNxKzAVYsXC/mZXuBDS1hiCDaQSl/3XUqVGjs92GVWBKk1p9qjnTQzDnk8VOCxFSw3le0q7GrPOdm7L1ZrIdVg0Wl/BuBX2CTMUsFJDAbR/J8Fjywl3+p4pDk1hF9ewX7Xl3+TKXwg6CVXmi5cTJXZxdYe6RI+tDfX0DCuvQBiwBJESXhyeLQYI/9wWjzmcBzdqUrULc48xY6sOMmNlJwzVg6FLn7x/1IeNUTcvs51P2VOmYPwDZFt6+m4scoeAD7qvOxaoVD49jI+7TipeR/gHaQj/wpOE=
 
 script:
   - cargo build --release --verbose
@@ -20,10 +21,12 @@ script:
 
 before_deploy:
   - cargo package --verbose
+  - cargo doc --release --verbose
+  - ./save_credentials.sh "$GITHUB_TOKEN" "$TRAVIS_REPO_SLUG"
 
 deploy:
   provider: script
-  script: deploy.sh $TRAVIS_TAG $CRATES_IO_TOKEN
+  script: ./deploy.sh "$TRAVIS_TAG" "$CRATES_IO_TOKEN"
   skip_cleanup: true
   on:
     tags: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,7 +10,4 @@ then
   echo "Tag $TAG doesn't appear to be the version in Cargo.toml"
 fi
 
-gpg --keyserver pgp.mit.edu --recv-keys E583F750
-gpg --list-keys
-git tag -v "$TAG"
 cargo publish --verbose --token "$TOKEN"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+TAG=${1:?'Missing tag to publish for'}
+TOKEN=${2:?'Missing crates.io token to publish with'}
+
+if ! grep -Fxq "version = "'"'"$TAG"'"' Cargo.toml
+then
+  echo "Tag $TAG doesn't appear to be the version in Cargo.toml"
+fi
+
+gpg --keyserver pgp.mit.edu --recv-keys E583F750
+gpg --list-keys
+git tag -v "$TAG"
+cargo publish --verbose --token "$TOKEN"

--- a/deploy.sh
+++ b/deploy.sh
@@ -11,3 +11,23 @@ then
 fi
 
 cargo publish --verbose --token "$TOKEN"
+
+# Setup this repo to publish the docs
+git fetch origin gh-pages
+git checkout -b gh-pages FETCH_HEAD
+
+# Move the built docs into versioned folder
+mv target/doc docs/$TAG
+
+# Update the index to point to the versioned docs
+sed -i'' -e '/<!-- TRAVIS: PUT THE DOCS HERE-->/a\
+<li><a href="docs/'"$TAG"'/hamlet/">'"$TAG"'</a></li>
+' index.html
+
+# Add the changes
+git add docs/$TAG
+git add index.html
+
+# Commit and push
+git commit -m "Add API docs for $TAG"
+git push origin gh-pages:gh-pages

--- a/save_credentials.sh
+++ b/save_credentials.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+: ${TRAVIS:?'This should only be run on Travis CI'}
+GITHUB_TOKEN=${1:?'Must provide github token'}
+REPO_SLUG=${2:?'Must provide repo slug'}
+
+echo "machine github.com login $GITHUB_TOKEN password x-oauth-basic" >> ~/.netrc
+chmod 0600 ~/.netrc
+git remote set-url --push origin "https://github.com/$REPO_SLUG"


### PR DESCRIPTION
`git tag -v` verifies that the tag is signed (via `git tag -s`) with a valid signature of someone in the local gpg database (while ignoring whether that signature is trusted or not :frowning:). I'm importing my key (E583F750), if you have a pgp key published somewhere I can add that as well so you can publish via this as well.

I normally just go with the security offered by github only allowing owners to push tags into repositories for ensuring auto-publish isn't abused, but I've always been meaning to look into using signed tags and thought this is probably a good use-case for them. Not entirely convinced it's that useful as anyone that could get a tag into the repository could probably get a commit in removing this check as well, let me know if you think it's worth leaving in or should be removed.
